### PR TITLE
Allow CORS for GET, HEAD, POST requests

### DIFF
--- a/src/main/java/com/dminc/dts/budget/tracker/ws/App.java
+++ b/src/main/java/com/dminc/dts/budget/tracker/ws/App.java
@@ -3,8 +3,13 @@ package com.dminc.dts.budget.tracker.ws;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {"com.dminc.dts.budget.tracker.controllers"} )
@@ -17,5 +22,14 @@ public class App {
         SpringApplication.run(App.class, args);
     }
 
+    @Bean
+    public FilterRegistrationBean corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration().applyPermitDefaultValues();
+        source.registerCorsConfiguration("/**", config);
+        FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+        bean.setOrder(0);
+        return bean;
+    }
 
 }


### PR DESCRIPTION
This change allows the react application to successfully make requests against a locally-running back end.
